### PR TITLE
Improve locale switching and translations

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { useParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 
 // Components effectivement utilisés dans la homepage
 import { CaseStudySection } from '@/components/organisms/CaseStudySection';
@@ -25,7 +25,7 @@ import ShadcnExpertiseGrid from '@/components/organisms/ShadcnExpertiseGrid';
 // import EnhancedTabLayout supprimé
 
 export default function HomePage() {
-  const { locale } = useParams();
+  const tHero = useTranslations('home.hero');
 
   return (
     <BaseLayout>
@@ -34,10 +34,10 @@ export default function HomePage() {
 
         <main className="flex flex-col">
         {/* 01 - Background Paths Hero Section */}
-        <BackgroundPaths 
-          title="AGENCE DE COMMUNICATION ET PRODUCTION" 
-          subtitle="ÉVÉNEMENTIEL CORPORATE ET GRAND PUBLIC · MARKETING ALTERNATIF · ROADSHOW ET ACTIVATIONS"
-          buttonText={locale === 'fr' ? 'Découvrir l\'Excellence' : 'Discover Excellence'}
+        <BackgroundPaths
+          title={tHero('title')}
+          subtitle={tHero('subtitle')}
+          buttonText={tHero('cta')}
         />
         
         {/* 02 - Modern Mantra Section - "Genius, it's not just a word" */}

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -6,21 +6,11 @@ import EnhancedHeader from '@/components/organisms/EnhancedHeader';
 import { Footer } from '@/components/organisms/Footer';
 import { Typography } from '@/components/atoms/Typography';
 import { motion } from 'framer-motion';
-import { useLocale } from 'next-intl';
+import { useTranslations } from 'next-intl';
 
 export default function GalleryPage() {
-  const locale = useLocale() as 'fr' | 'en';
-  
-  const title = {
-    fr: 'NOTRE GALERIE',
-    en: 'OUR GALLERY'
-  };
-  
-  const subtitle = {
-    fr: 'Découvrez notre portfolio d\'œuvres créatives et nos réalisations récentes',
-    en: 'Explore our portfolio of creative works and recent achievements'
-  };
-  
+  const tGallery = useTranslations('gallery.page');
+
   return (
     <div className="min-h-screen bg-black text-white">
       <EnhancedHeader transparent={false} />
@@ -41,11 +31,11 @@ export default function GalleryPage() {
               className="max-w-4xl mx-auto text-center"
             >
               <Typography variant="h1" className="mb-6">
-                {title[locale]}
+                {tGallery('title')}
               </Typography>
-              
+
               <Typography variant="body" color="muted" className="text-xl max-w-2xl mx-auto">
-                {subtitle[locale]}
+                {tGallery('subtitle')}
               </Typography>
             </motion.div>
           </div>
@@ -60,16 +50,13 @@ export default function GalleryPage() {
         </section>
         
         {/* Gallery Section */}
-        <EnhancedGalleryFixed 
-          showFilters={true} 
-          title={{ fr: 'EXPLOREZ NOS PROJETS', en: 'EXPLORE OUR PROJECTS' }}
-          subtitle={{
-            fr: 'Filtrez par catégorie pour découvrir nos différentes réalisations',
-            en: 'Filter by category to discover our different achievements'
-          }}
+        <EnhancedGalleryFixed
+          showFilters={true}
+          titleOverride={tGallery('sectionTitle')}
+          subtitleOverride={tGallery('sectionSubtitle')}
         />
       </main>
-      
+
       <Footer />
     </div>
   );

--- a/src/components/molecules/LanguageSwitcher.tsx
+++ b/src/components/molecules/LanguageSwitcher.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { useLocale, useTranslations } from 'next-intl';
+import { usePathname } from 'next/navigation';
 import { Link } from '@/navigation';
 import { Button } from '@/components/atoms/Button';
 
@@ -11,15 +12,18 @@ interface LanguageSwitcherProps {
 
 export const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ className = '' }) => {
   const locale = useLocale();
-  const t = useTranslations('common');
-  
+  const pathname = usePathname();
+  const t = useTranslations('common.languageSwitcher');
+
   // Determine the opposite locale for switching
   const oppositeLocale = locale === 'en' ? 'fr' : 'en';
-  
+  const switchLabel = oppositeLocale === 'fr' ? t('switchToFrench') : t('switchToEnglish');
+  const shortLabel = oppositeLocale === 'fr' ? t('short.fr') : t('short.en');
+
   return (
-    <Link href="/" locale={oppositeLocale} className={className}>
-      <Button variant="ghost" size="sm">
-        {t('switchLanguage')}
+    <Link href={pathname || '/'} locale={oppositeLocale} className={className}>
+      <Button variant="ghost" size="sm" aria-label={switchLabel} title={switchLabel}>
+        {shortLabel}
       </Button>
     </Link>
   );

--- a/src/components/organisms/AppleFooter.tsx
+++ b/src/components/organisms/AppleFooter.tsx
@@ -1,44 +1,48 @@
 "use client";
 
 import React from 'react';
-import Link from 'next/link';
-import { motion } from 'framer-motion';
+import { useLocale, useTranslations } from 'next-intl';
+import { Link } from '@/navigation';
 import { ChevronRight } from 'lucide-react';
-import Image from 'next/image';
-
-// Garder uniquement les liens nécessaires et actifs
-const footerLinks = [
-  {
-    title: 'Entreprise',
-    links: [
-      { label: 'Notre histoire', href: '/notre-histoire' },
-      { label: 'Nos valeurs', href: '/nos-valeurs' },
-      { label: 'Notre équipe', href: '/notre-equipe' },
-      { label: 'Expertise', href: '/expertise' },
-      { label: 'Projets', href: '/projets' },
-    ],
-  },
-  {
-    title: 'Filiales',
-    links: [
-      { label: 'MPS', href: '/mps' },
-      { label: 'Labrigad', href: '/labrigad' },
-      { label: 'Gamius', href: '/gamius' },
-      { label: 'Genius Lab', href: '/genius-lab' },
-    ],
-  },
-  {
-    title: 'Légal',
-    links: [
-      { label: 'Mentions légales', href: '/mentions-legales' },
-      { label: 'Politique de confidentialité', href: '/confidentialite' },
-      { label: 'Politique de cookies', href: '/cookies' },
-      { label: 'CGV', href: '/cgv' },
-    ],
-  },
-];
 
 export const AppleFooter = () => {
+  const locale = useLocale();
+  const tNavbar = useTranslations('navbar.menu');
+  const tFooter = useTranslations('footer');
+
+  const footerLinks = [
+    {
+      title: tFooter('sections.company.title'),
+      links: [
+        { label: tNavbar('about.links.history'), href: `/${locale}/a-propos/notre-histoire` },
+        { label: tNavbar('about.links.values'), href: `/${locale}/a-propos/nos-valeurs` },
+        { label: tNavbar('about.links.team'), href: `/${locale}/a-propos/notre-equipe` },
+        { label: tNavbar('about.links.expertise'), href: `/${locale}/a-propos/expertises` },
+        { label: tNavbar('projects.label'), href: `/${locale}/projets` },
+      ],
+    },
+    {
+      title: tFooter('sections.subsidiaries.title'),
+      links: [
+        { label: tNavbar('subsidiaries.links.mps'), href: `/${locale}/filiales/mps` },
+        { label: tNavbar('subsidiaries.links.labrigad'), href: `/${locale}/filiales/labrigad` },
+        { label: tNavbar('subsidiaries.links.gamius'), href: `/${locale}/filiales/gamius` },
+        { label: tNavbar('subsidiaries.links.moujeleell'), href: `/${locale}/filiales/moujeleell` },
+      ],
+    },
+    {
+      title: tFooter('sections.legal.title'),
+      links: [
+        { label: tFooter('sections.legal.links.legalNotice'), href: `/${locale}/mentions-legales` },
+        { label: tFooter('sections.legal.links.privacy'), href: `/${locale}/confidentialite` },
+        { label: tFooter('sections.legal.links.cookies'), href: `/${locale}/cookies` },
+        { label: tFooter('sections.legal.links.terms'), href: `/${locale}/cgv` },
+      ],
+    },
+  ];
+
+  const currentYear = new Date().getFullYear();
+
   return (
     <footer className="border-t border-white/10 bg-black text-white">
       <div className="mx-auto max-w-7xl px-6 py-12">
@@ -70,26 +74,26 @@ export const AppleFooter = () => {
         {/* Bottom Bar simplifié */}
         <div className="pt-8 border-t border-white/10 flex flex-col md:flex-row justify-between items-center">
           <p className="text-white/40 text-xs">
-            © {new Date().getFullYear()} Genius Ad District. Tous droits réservés.
+            {tFooter('bottom.copyright', { year: currentYear })}
           </p>
           <div className="flex space-x-6 items-center mt-4 md:mt-0">
-            <a 
-              href="https://www.linkedin.com/company/genius-ad-district/" 
+            <a
+              href="https://www.linkedin.com/company/genius-ad-district/"
               target="_blank"
               rel="noopener noreferrer"
               className="text-white/60 hover:text-white text-xs transition-colors duration-200"
-              aria-label="LinkedIn"
+              aria-label={tFooter('social.linkedin')}
             >
-              LinkedIn
+              {tFooter('social.linkedin')}
             </a>
-            <a 
-              href="https://www.instagram.com/genius.ad.district.morocco/" 
+            <a
+              href="https://www.instagram.com/genius.ad.district.morocco/"
               target="_blank"
               rel="noopener noreferrer"
               className="text-white/60 hover:text-white text-xs transition-colors duration-200"
-              aria-label="Instagram"
+              aria-label={tFooter('social.instagram')}
             >
-              Instagram
+              {tFooter('social.instagram')}
             </a>
           </div>
         </div>

--- a/src/components/organisms/EnhancedGalleryFixed.tsx
+++ b/src/components/organisms/EnhancedGalleryFixed.tsx
@@ -5,7 +5,8 @@ import Image from 'next/image';
 import { motion, AnimatePresence, MotionConfig } from 'framer-motion';
 import { Typography } from '@/components/atoms/Typography';
 import { Button } from '@/components/ui/button';
-import { useLocale } from 'next-intl';
+import { Link } from '@/navigation';
+import { useLocale, useTranslations } from 'next-intl';
 
 // Définition des projets de la galerie avec données de localisation
 const GALLERY_PROJECTS = [
@@ -78,23 +79,21 @@ interface LocaleText {
 // Props du composant de galerie
 interface EnhancedGalleryFixedProps {
   limit?: number;
-  title?: LocaleText;
-  subtitle?: LocaleText;
+  titleOverride?: string;
+  subtitleOverride?: string;
   className?: string;
   showFilters?: boolean;
 }
 
-const EnhancedGalleryFixed: React.FC<EnhancedGalleryFixedProps> = ({ 
-  limit = GALLERY_PROJECTS.length, 
-  title = { fr: 'NOS PROJETS', en: 'OUR PROJECTS' },
-  subtitle = { 
-    fr: 'Découvrez nos réalisations récentes et comment nous transformons les marques',
-    en: 'Discover our recent achievements and how we transform brands'
-  },
+const EnhancedGalleryFixed: React.FC<EnhancedGalleryFixedProps> = ({
+  limit = GALLERY_PROJECTS.length,
+  titleOverride,
+  subtitleOverride,
   className = '',
   showFilters = false
 }) => {
   const locale = useLocale();
+  const tGallery = useTranslations('gallery');
   const [isLoading, setIsLoading] = useState(true);
   const [selectedProject, setSelectedProject] = useState<typeof GALLERY_PROJECTS[0] | null>(null);
   const [imageIndex, setImageIndex] = useState(0);
@@ -167,10 +166,10 @@ const EnhancedGalleryFixed: React.FC<EnhancedGalleryFixedProps> = ({
           {/* Titre et sous-titre */}
           <div className="text-center max-w-3xl mx-auto mb-16">
             <Typography variant="h2" className="mb-4">
-              {title[locale as keyof LocaleText]}
+              {titleOverride ?? tGallery('page.sectionTitle')}
             </Typography>
             <Typography variant="body" color="muted" className="md:text-lg max-w-2xl mx-auto">
-              {subtitle[locale as keyof LocaleText]}
+              {subtitleOverride ?? tGallery('page.sectionSubtitle')}
             </Typography>
           </div>
           
@@ -183,7 +182,7 @@ const EnhancedGalleryFixed: React.FC<EnhancedGalleryFixedProps> = ({
                 }`}
                 onClick={() => setActiveCategory(null)}
               >
-                {locale === 'fr' ? 'Tous' : 'All'}
+                {tGallery('filters.all')}
               </button>
               
               {categories.map((category) => (
@@ -361,7 +360,7 @@ const EnhancedGalleryFixed: React.FC<EnhancedGalleryFixedProps> = ({
                       <div className="flex flex-wrap gap-4 mb-8">
                         <div className="bg-white/10 rounded-lg p-3">
                           <Typography variant="body" color="muted" className="text-xs">
-                            {locale === 'fr' ? 'CATÉGORIE' : 'CATEGORY'}
+                            {tGallery('modal.category')}
                           </Typography>
                           <Typography variant="body" className="font-medium">
                             {selectedProject.category[locale as keyof LocaleText]}
@@ -370,7 +369,7 @@ const EnhancedGalleryFixed: React.FC<EnhancedGalleryFixedProps> = ({
                         
                         <div className="bg-white/10 rounded-lg p-3">
                           <Typography variant="body" color="muted" className="text-xs">
-                            {locale === 'fr' ? 'CLIENT' : 'CLIENT'}
+                            {tGallery('modal.client')}
                           </Typography>
                           <Typography variant="body" className="font-medium">
                             {selectedProject.client}
@@ -379,7 +378,7 @@ const EnhancedGalleryFixed: React.FC<EnhancedGalleryFixedProps> = ({
                         
                         <div className="bg-white/10 rounded-lg p-3">
                           <Typography variant="body" color="muted" className="text-xs">
-                            {locale === 'fr' ? 'ANNÉE' : 'YEAR'}
+                            {tGallery('modal.year')}
                           </Typography>
                           <Typography variant="body" className="font-medium">
                             {selectedProject.year}
@@ -388,7 +387,7 @@ const EnhancedGalleryFixed: React.FC<EnhancedGalleryFixedProps> = ({
                       </div>
                       
                       <Typography variant="h6" className="mb-4">
-                        {locale === 'fr' ? 'À propos du projet' : 'About the project'}
+                        {tGallery('modal.about')}
                       </Typography>
                       
                       <Typography variant="body" color="muted" className="mb-8">
@@ -398,7 +397,7 @@ const EnhancedGalleryFixed: React.FC<EnhancedGalleryFixedProps> = ({
                       {/* Miniatures */}
                       <div className="space-y-4">
                         <Typography variant="body" color="muted" className="text-sm">
-                          {locale === 'fr' ? 'GALERIE D\'IMAGES' : 'IMAGE GALLERY'}
+                          {tGallery('modal.gallery')}
                         </Typography>
                         
                         <div className="grid grid-cols-4 gap-3">
@@ -459,15 +458,15 @@ const EnhancedGalleryFixed: React.FC<EnhancedGalleryFixedProps> = ({
           {/* Bouton pour voir plus de projets */}
           {limit < GALLERY_PROJECTS.length && (
             <div className="mt-16 text-center">
-              <Button 
-                variant="outline" 
+              <Button
+                variant="outline"
                 size="lg"
                 className="border-white/20 hover:bg-white/10"
                 asChild
               >
-                <a href="/gallery">
-                  {locale === 'fr' ? 'Voir tous les projets' : 'View all projects'}
-                </a>
+                <Link href="/gallery">
+                  {tGallery('cta')}
+                </Link>
               </Button>
             </div>
           )}

--- a/src/components/organisms/EnhancedHeader.tsx
+++ b/src/components/organisms/EnhancedHeader.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { AnimatePresence, motion } from 'framer-motion';
-import { useLocale } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { Link as IntlLink } from '@/navigation';
 
 interface EnhancedHeaderProps {
@@ -17,6 +17,9 @@ const EnhancedHeader: React.FC<EnhancedHeaderProps> = ({ transparent = false }) 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const pathname = usePathname();
   const locale = useLocale();
+  const tNav = useTranslations('common.navigation');
+  const tLanguage = useTranslations('common.languageSwitcher');
+  const tAccessibility = useTranslations('common.accessibility');
 
   // Handle scroll events
   useEffect(() => {
@@ -56,13 +59,21 @@ const EnhancedHeader: React.FC<EnhancedHeaderProps> = ({ transparent = false }) 
 
   // Navigation links
   const navLinks = [
-    { name: locale === 'fr' ? 'Accueil' : 'Home', path: '/' },
-    { name: locale === 'fr' ? 'À propos' : 'About', path: '/about' },
-    { name: locale === 'fr' ? 'Filiales' : 'Subsidiaries', path: '/filiales' },
-    { name: locale === 'fr' ? 'Services' : 'Services', path: '/services' },
-    { name: locale === 'fr' ? 'Galerie' : 'Gallery', path: '/gallery' },
-    { name: locale === 'fr' ? 'Contact' : 'Contact', path: '/contact' },
+    { name: tNav('home'), path: '/' },
+    { name: tNav('about'), path: '/about' },
+    { name: tNav('subsidiaries'), path: '/filiales' },
+    { name: tNav('services'), path: '/services' },
+    { name: tNav('gallery'), path: '/gallery' },
+    { name: tNav('contact'), path: '/contact' },
   ];
+
+  const oppositeLocale = locale === 'fr' ? 'en' : 'fr';
+  const languageButtonLabel = oppositeLocale === 'fr'
+    ? tLanguage('switchToFrench')
+    : tLanguage('switchToEnglish');
+  const languageButtonShort = oppositeLocale === 'fr'
+    ? tLanguage('short.fr')
+    : tLanguage('short.en');
 
   // Animation variants
   const headerVariants = {
@@ -161,9 +172,13 @@ const EnhancedHeader: React.FC<EnhancedHeaderProps> = ({ transparent = false }) 
           {/* Language Switcher & Mobile Menu Button */}
           <div className="flex items-center space-x-4">
             <div className="hidden sm:block">
-              <IntlLink href={pathname || '/'} locale={locale === 'fr' ? 'en' : 'fr'}>
-                <button className="px-2 py-1 text-sm text-gray-300 hover:text-white bg-transparent hover:bg-white/10 rounded transition-colors">
-                  {locale === 'fr' ? 'EN' : 'FR'}
+              <IntlLink href={pathname || '/'} locale={oppositeLocale}>
+                <button
+                  className="px-2 py-1 text-sm text-gray-300 hover:text-white bg-transparent hover:bg-white/10 rounded transition-colors"
+                  aria-label={languageButtonLabel}
+                  title={languageButtonLabel}
+                >
+                  {languageButtonShort}
                 </button>
               </IntlLink>
             </div>
@@ -172,7 +187,7 @@ const EnhancedHeader: React.FC<EnhancedHeaderProps> = ({ transparent = false }) 
             <button
               onClick={() => setIsMenuOpen(!isMenuOpen)}
               className="lg:hidden relative z-10 w-10 h-10 flex items-center justify-center"
-              aria-label={isMenuOpen ? "Close menu" : "Open menu"}
+              aria-label={isMenuOpen ? tAccessibility('closeMenu') : tAccessibility('openMenu')}
             >
               <div className="relative w-6 h-5">
                 <span 
@@ -237,9 +252,12 @@ const EnhancedHeader: React.FC<EnhancedHeaderProps> = ({ transparent = false }) 
               
               {/* Mobile Language Switcher */}
               <motion.div variants={itemVariants} className="pt-4 border-t border-gray-800">
-                <IntlLink href={pathname || '/'} locale={locale === 'fr' ? 'en' : 'fr'}>
-                  <button className="w-full text-left px-4 py-2 text-gray-300 hover:text-white hover:bg-white/5 rounded transition-colors">
-                    {locale === 'fr' ? 'Switch to English' : 'Passer en Français'}
+                <IntlLink href={pathname || '/'} locale={oppositeLocale}>
+                  <button
+                    className="w-full text-left px-4 py-2 text-gray-300 hover:text-white hover:bg-white/5 rounded transition-colors"
+                    aria-label={languageButtonLabel}
+                  >
+                    {languageButtonLabel}
                   </button>
                 </IntlLink>
               </motion.div>

--- a/src/components/organisms/SubsidiaryHeader.tsx
+++ b/src/components/organisms/SubsidiaryHeader.tsx
@@ -2,11 +2,9 @@
 
 import React, { useState, useEffect } from 'react';
 import Image from 'next/image';
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
 import { AnimatePresence, motion } from 'framer-motion';
-import { useLocale } from 'next-intl';
-import { Link as IntlLink } from '@/navigation';
+import { useLocale, useTranslations } from 'next-intl';
+import { Link, usePathname } from '@/navigation';
 import { filiales } from '@/components/ui/navbar-demo';
 import { AlertCircle } from 'lucide-react';
 
@@ -24,6 +22,10 @@ const SubsidiaryHeader: React.FC<SubsidiaryHeaderProps> = ({
   const [showReturnBanner, setShowReturnBanner] = useState(true);
   const pathname = usePathname();
   const locale = useLocale();
+  const tNav = useTranslations('common.navigation');
+  const tLanguage = useTranslations('common.languageSwitcher');
+  const tAccessibility = useTranslations('common.accessibility');
+  const tBanner = useTranslations('subsidiaryHeader.banner');
   
   const subsidiaryData = filiales[subsidiarySlug] || filiales.genius;
 
@@ -65,11 +67,19 @@ const SubsidiaryHeader: React.FC<SubsidiaryHeaderProps> = ({
 
   // Navigation links - these can be customized per subsidiary
   const navLinks = [
-    { name: locale === 'fr' ? 'Accueil' : 'Home', path: `/filiales/${subsidiarySlug}` },
-    { name: locale === 'fr' ? 'Services' : 'Services', path: `/filiales/${subsidiarySlug}/services` },
-    { name: locale === 'fr' ? 'Projets' : 'Projects', path: `/filiales/${subsidiarySlug}/projects` },
-    { name: locale === 'fr' ? 'Contact' : 'Contact', path: '/contact' },
+    { name: tNav('home'), path: `/filiales/${subsidiarySlug}` },
+    { name: tNav('services'), path: `/filiales/${subsidiarySlug}/services` },
+    { name: tNav('projects'), path: `/filiales/${subsidiarySlug}/projects` },
+    { name: tNav('contact'), path: '/contact' },
   ];
+
+  const oppositeLocale = locale === 'fr' ? 'en' : 'fr';
+  const languageButtonLabel = oppositeLocale === 'fr'
+    ? tLanguage('switchToFrench')
+    : tLanguage('switchToEnglish');
+  const languageButtonShort = oppositeLocale === 'fr'
+    ? tLanguage('short.fr')
+    : tLanguage('short.en');
 
   // Animation variants
   const headerVariants = {
@@ -146,19 +156,16 @@ const SubsidiaryHeader: React.FC<SubsidiaryHeaderProps> = ({
             <div className="flex items-center space-x-2 text-sm">
               <AlertCircle className="w-4 h-4" />
               <span>
-                {locale === 'fr' 
-                  ? 'Vous êtes sur le site de ' 
-                  : 'You are on the '} 
-                <strong>{subsidiaryData.name}</strong> 
-                {locale === 'fr' ? '. ' : ' website. '}
+                {tBanner('message', { subsidiary: subsidiaryData.name })}{' '}
                 <Link href="/" className="underline hover:text-white">
-                  {locale === 'fr' ? 'Retourner à Genius AD District' : 'Return to Genius AD District'}
+                  {tBanner('return')}
                 </Link>
               </span>
             </div>
-            <button 
+            <button
               onClick={() => setShowReturnBanner(false)}
               className="text-white/70 hover:text-white"
+              aria-label={tBanner('dismiss')}
             >
               ×
             </button>
@@ -219,18 +226,22 @@ const SubsidiaryHeader: React.FC<SubsidiaryHeaderProps> = ({
             {/* Language Switcher & Mobile Menu Button */}
             <div className="flex items-center space-x-4">
               <div className="hidden sm:block">
-                <IntlLink href={pathname || '/'} locale={locale === 'fr' ? 'en' : 'fr'}>
-                  <button className="px-2 py-1 text-sm text-gray-300 hover:text-white bg-transparent hover:bg-white/10 rounded transition-colors">
-                    {locale === 'fr' ? 'EN' : 'FR'}
+                <Link href={pathname || '/'} locale={oppositeLocale}>
+                  <button
+                    className="px-2 py-1 text-sm text-gray-300 hover:text-white bg-transparent hover:bg-white/10 rounded transition-colors"
+                    aria-label={languageButtonLabel}
+                    title={languageButtonLabel}
+                  >
+                    {languageButtonShort}
                   </button>
-                </IntlLink>
+                </Link>
               </div>
               
               {/* Mobile Menu Toggle Button */}
               <button
                 onClick={() => setIsMenuOpen(!isMenuOpen)}
                 className="lg:hidden relative z-10 w-10 h-10 flex items-center justify-center"
-                aria-label={isMenuOpen ? "Close menu" : "Open menu"}
+                aria-label={isMenuOpen ? tAccessibility('closeMenu') : tAccessibility('openMenu')}
               >
                 <div className="relative w-6 h-5">
                   <span 
@@ -293,23 +304,26 @@ const SubsidiaryHeader: React.FC<SubsidiaryHeaderProps> = ({
                   
                   {/* Return to Genius Link in Mobile Menu */}
                   <motion.div variants={itemVariants}>
-                    <Link 
+                    <Link
                       href="/"
                       className="block text-xl font-medium text-gray-400 hover:text-white transition-colors duration-300"
                       onClick={() => setIsMenuOpen(false)}
                     >
-                      {locale === 'fr' ? 'Genius AD District' : 'Genius AD District'}
+                      {tBanner('return')}
                     </Link>
                   </motion.div>
                 </nav>
                 
                 {/* Mobile Language Switcher */}
                 <motion.div variants={itemVariants} className="pt-4 border-t border-gray-800">
-                  <IntlLink href={pathname || '/'} locale={locale === 'fr' ? 'en' : 'fr'}>
-                    <button className="w-full text-left px-4 py-2 text-gray-300 hover:text-white hover:bg-white/5 rounded transition-colors">
-                      {locale === 'fr' ? 'Switch to English' : 'Passer en Français'}
+                  <Link href={pathname || '/'} locale={oppositeLocale}>
+                    <button
+                      className="w-full text-left px-4 py-2 text-gray-300 hover:text-white hover:bg-white/5 rounded transition-colors"
+                      aria-label={languageButtonLabel}
+                    >
+                      {languageButtonLabel}
                     </button>
-                  </IntlLink>
+                  </Link>
                 </motion.div>
               </div>
             </motion.div>

--- a/src/components/ui/navbar-demo.tsx
+++ b/src/components/ui/navbar-demo.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, type ReactNode } from 'react';
 import { Info, Building2, Briefcase, Code2, Layers, ChevronDown, ChevronUp } from 'lucide-react';
-import { useParams } from 'next/navigation';
+import { useLocale, useTranslations } from 'next-intl';
+import { usePathname } from 'next/navigation';
 import Image from "next/image";
 import { cn } from "@/lib/utils";
-import Link from 'next/link';
+import { Link } from '@/navigation';
 
 // Interface pour les sous-sites des filiales
 export interface FilialeSite {
@@ -73,12 +74,12 @@ const AnimatedMenuIcon = ({ isOpen }: { isOpen: boolean }) => (
 );
 
 // Mapping des icônes pour les éléments du menu
-const menuIcons: Record<string, React.ReactNode> = {
-  'À propos': <Info className="w-5 h-5 mr-2" />,
-  'Filiales': <Building2 className="w-5 h-5 mr-2" />,
-  'Services': <Briefcase className="w-5 h-5 mr-2" />,
-  'Expertises': <Code2 className="w-5 h-5 mr-2" />,
-  'Projets': <Layers className="w-5 h-5 mr-2" />,
+const menuIcons: Record<string, ReactNode> = {
+  about: <Info className="w-5 h-5 mr-2" />,
+  subsidiaries: <Building2 className="w-5 h-5 mr-2" />,
+  services: <Briefcase className="w-5 h-5 mr-2" />,
+  expertise: <Code2 className="w-5 h-5 mr-2" />,
+  projects: <Layers className="w-5 h-5 mr-2" />,
 };
 
 export function ModernNavbar({ className, currentFiliale = 'genius' }: ModernNavbarProps) {
@@ -86,7 +87,10 @@ export function ModernNavbar({ className, currentFiliale = 'genius' }: ModernNav
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   
   // Obtenir les informations de la locale depuis les paramètres d'URL
-  const { locale = 'fr' } = useParams();
+  const locale = useLocale();
+  const pathname = usePathname();
+  const tNavbar = useTranslations('navbar.menu');
+  const tLanguage = useTranslations('common.languageSwitcher');
   
   // Obtenir les données de la filiale actuelle
   const filialeData = filiales[currentFiliale] || filiales.genius;
@@ -107,38 +111,44 @@ export function ModernNavbar({ className, currentFiliale = 'genius' }: ModernNav
   // Structure du menu basée sur le sitemap
   const navItems = [
     {
-      name: locale === 'fr' ? 'À propos' : 'About',
-      url: null, // Make non-clickable
+      id: 'about',
+      name: tNavbar('about.label'),
+      url: null as string | null,
       icon: Info,
       submenu: [
-        { name: locale === 'fr' ? 'Notre histoire' : 'Our History', url: `/${locale}/a-propos/notre-histoire` },
-        { name: locale === 'fr' ? 'Notre équipe' : 'Our Team', url: `/${locale}/a-propos/notre-equipe` },
-        { name: locale === 'fr' ? 'Nos valeurs' : 'Our Values', url: `/${locale}/a-propos/nos-valeurs` },
-        { name: locale === 'fr' ? 'Expertises' : 'Expertise', url: `/${locale}/a-propos/expertises` },
+        { id: 'history', name: tNavbar('about.links.history'), url: `/${locale}/a-propos/notre-histoire` },
+        { id: 'team', name: tNavbar('about.links.team'), url: `/${locale}/a-propos/notre-equipe` },
+        { id: 'values', name: tNavbar('about.links.values'), url: `/${locale}/a-propos/nos-valeurs` },
+        { id: 'expertise', name: tNavbar('about.links.expertise'), url: `/${locale}/a-propos/expertises` },
       ],
     },
     {
-      name: locale === 'fr' ? 'Filiales' : 'Subsidiaries',
-      url: null, // Make non-clickable
+      id: 'subsidiaries',
+      name: tNavbar('subsidiaries.label'),
+      url: null as string | null,
       icon: Building2,
       submenu: [
-        { name: 'MPS', url: `/${locale}/filiales/mps` },
-        { name: "LABRIG'Ad", url: `/${locale}/filiales/labrigad` },
-        { name: 'Gamius', url: `/${locale}/filiales/gamius` },
-        { name: 'Mouje & Leell', url: `/${locale}/filiales/moujeleell` },
+        { id: 'mps', name: tNavbar('subsidiaries.links.mps'), url: `/${locale}/filiales/mps` },
+        { id: 'labrigad', name: tNavbar("subsidiaries.links.labrigad"), url: `/${locale}/filiales/labrigad` },
+        { id: 'gamius', name: tNavbar('subsidiaries.links.gamius'), url: `/${locale}/filiales/gamius` },
+        { id: 'moujeleell', name: tNavbar('subsidiaries.links.moujeleell'), url: `/${locale}/filiales/moujeleell` },
       ]
     },
     {
-      name: locale === 'fr' ? 'Services' : 'Services',
+      id: 'services',
+      name: tNavbar('services.label'),
       url: `/${locale}/services`,
       icon: Briefcase
     },
     {
-      name: locale === 'fr' ? 'Projets' : 'Projects',
+      id: 'projects',
+      name: tNavbar('projects.label'),
       url: `/${locale}/projets`,
       icon: Layers
     },
   ];
+
+  const languages: Array<'fr' | 'en'> = ['fr', 'en'];
 
   return (
     <header className={cn(
@@ -211,24 +221,32 @@ export function ModernNavbar({ className, currentFiliale = 'genius' }: ModernNav
           
           {/* Language Switcher - Desktop (properly positioned on right) */}
           <div className="hidden md:flex items-center space-x-2 ml-auto">
-            <Link 
-              href="/fr"
-              className={cn(
-                "px-3 py-1 text-sm border border-white/20 rounded-md hover:bg-white/10 transition-colors",
-                locale === 'fr' ? "bg-white text-black border-white" : "text-white"
-              )}
-            >
-              FR
-            </Link>
-            <Link 
-              href="/en"
-              className={cn(
-                "px-3 py-1 text-sm border border-white/20 rounded-md hover:bg-white/10 transition-colors",
-                locale === 'en' ? "bg-white text-black border-white" : "text-white"
-              )}
-            >
-              EN
-            </Link>
+            {languages.map((lang) => {
+              const isActive = locale === lang;
+              const shortLabel = tLanguage(`short.${lang}` as const);
+              const languageName = tLanguage(`languageNames.${lang}` as const);
+              const ariaLabel = isActive
+                ? tLanguage('current', { language: languageName })
+                : lang === 'fr'
+                  ? tLanguage('switchToFrench')
+                  : tLanguage('switchToEnglish');
+
+              return (
+                <Link
+                  key={lang}
+                  href={pathname || '/'}
+                  locale={lang}
+                  className={cn(
+                    "px-3 py-1 text-sm border border-white/20 rounded-md hover:bg-white/10 transition-colors",
+                    isActive ? "bg-white text-black border-white" : "text-white"
+                  )}
+                  aria-label={ariaLabel}
+                  title={ariaLabel}
+                >
+                  {shortLabel}
+                </Link>
+              );
+            })}
           </div>
           
           {/* Mobile menu button - centered */}
@@ -276,7 +294,7 @@ export function ModernNavbar({ className, currentFiliale = 'genius' }: ModernNav
             {navItems.map((item) => {
               const [subMenuOpen, setSubMenuOpen] = useState(false);
               return (
-                <div key={item.name} className="border border-white/10 rounded-lg overflow-hidden">
+                <div key={item.id} className="border border-white/10 rounded-lg overflow-hidden">
                   <div className="flex items-center justify-between">
                     {item.url ? (
                       <Link
@@ -292,7 +310,7 @@ export function ModernNavbar({ className, currentFiliale = 'genius' }: ModernNav
                         }}
                       >
                         <span className="flex items-center">
-                          {menuIcons[item.name]}
+                          {menuIcons[item.id]}
                           {item.name}
                         </span>
                       </Link>
@@ -302,7 +320,7 @@ export function ModernNavbar({ className, currentFiliale = 'genius' }: ModernNav
                         onClick={() => setSubMenuOpen(!subMenuOpen)}
                       >
                         <span className="flex items-center">
-                          {menuIcons[item.name]}
+                          {menuIcons[item.id]}
                           {item.name}
                         </span>
                       </button>
@@ -331,7 +349,7 @@ export function ModernNavbar({ className, currentFiliale = 'genius' }: ModernNav
                     >
                       {item.submenu.map((sub) => (
                         <Link
-                          key={sub.name}
+                          key={sub.id}
                           href={sub.url}
                           className="block px-8 py-3 text-sm text-white hover:bg-white/10 transition-colors"
                           onClick={() => setMobileMenuOpen(false)}
@@ -349,30 +367,35 @@ export function ModernNavbar({ className, currentFiliale = 'genius' }: ModernNav
           {/* Language switcher - Mobile */}
           <div className="mt-auto pt-4 border-t border-white/10">
             <div className="flex justify-center space-x-4">
-              <Link 
-                href="/fr"
-                className={cn(
-                  "px-5 py-2 rounded-full text-sm font-medium",
-                  locale === 'fr' 
-                    ? "bg-white text-black" 
-                    : "bg-black/50 text-white border border-white/20"
-                )}
-                onClick={() => setMobileMenuOpen(false)}
-              >
-                FR
-              </Link>
-              <Link 
-                href="/en"
-                className={cn(
-                  "px-5 py-2 rounded-full text-sm font-medium",
-                  locale === 'en' 
-                    ? "bg-white text-black" 
-                    : "bg-black/50 text-white border border-white/20"
-                )}
-                onClick={() => setMobileMenuOpen(false)}
-              >
-                EN
-              </Link>
+              {languages.map((lang) => {
+                const isActive = locale === lang;
+                const shortLabel = tLanguage(`short.${lang}` as const);
+                const languageName = tLanguage(`languageNames.${lang}` as const);
+                const ariaLabel = isActive
+                  ? tLanguage('current', { language: languageName })
+                  : lang === 'fr'
+                    ? tLanguage('switchToFrench')
+                    : tLanguage('switchToEnglish');
+
+                return (
+                  <Link
+                    key={lang}
+                    href={pathname || '/'}
+                    locale={lang}
+                    className={cn(
+                      "px-5 py-2 rounded-full text-sm font-medium",
+                      isActive
+                        ? "bg-white text-black"
+                        : "bg-black/50 text-white border border-white/20"
+                    )}
+                    onClick={() => setMobileMenuOpen(false)}
+                    aria-label={ariaLabel}
+                    title={ariaLabel}
+                  >
+                    {shortLabel}
+                  </Link>
+                );
+              })}
             </div>
           </div>
         </div>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1,12 +1,28 @@
 {
   "common": {
     "languageName": "English",
-    "switchLanguage": "Switch to French",
+    "switchLanguage": "Switch language",
+    "languageSwitcher": {
+      "switchToEnglish": "Switch to English",
+      "switchToFrench": "Switch to French",
+      "short": {
+        "en": "EN",
+        "fr": "FR"
+      },
+      "languageNames": {
+        "en": "English",
+        "fr": "French"
+      },
+      "current": "Current language: {language}"
+    },
     "navigation": {
       "home": "Home",
       "about": "About",
       "caseStudies": "Case Studies",
       "subsidiaries": "Subsidiaries",
+      "services": "Services",
+      "projects": "Projects",
+      "gallery": "Gallery",
       "contact": "Contact"
     },
     "footer": {
@@ -32,6 +48,10 @@
       "cancel": "Cancel",
       "save": "Save"
     },
+    "accessibility": {
+      "openMenu": "Open menu",
+      "closeMenu": "Close menu"
+    },
     "contact": {
       "title": "Contact",
       "form": {
@@ -41,6 +61,93 @@
         "subject": "Subject",
         "phone": "Phone"
       }
+    }
+  },
+  "navbar": {
+    "menu": {
+      "about": {
+        "label": "About",
+        "links": {
+          "history": "Our History",
+          "team": "Our Team",
+          "values": "Our Values",
+          "expertise": "Expertise"
+        }
+      },
+      "subsidiaries": {
+        "label": "Subsidiaries",
+        "links": {
+          "mps": "MPS",
+          "labrigad": "LABRIG'Ad",
+          "gamius": "Gamius",
+          "moujeleell": "Mouje & Leell"
+        }
+      },
+      "services": {
+        "label": "Services"
+      },
+      "projects": {
+        "label": "Projects"
+      }
+    }
+  },
+  "footer": {
+    "sections": {
+      "company": {
+        "title": "Company"
+      },
+      "subsidiaries": {
+        "title": "Subsidiaries"
+      },
+      "legal": {
+        "title": "Legal",
+        "links": {
+          "legalNotice": "Legal Notice",
+          "privacy": "Privacy Policy",
+          "cookies": "Cookie Policy",
+          "terms": "Terms & Conditions"
+        }
+      }
+    },
+    "social": {
+      "linkedin": "LinkedIn",
+      "instagram": "Instagram"
+    },
+    "bottom": {
+      "copyright": "© {year} Genius Ad District. All rights reserved."
+    }
+  },
+  "home": {
+    "hero": {
+      "title": "COMMUNICATION AND PRODUCTION AGENCY",
+      "subtitle": "CORPORATE & PUBLIC EVENTS · ALTERNATIVE MARKETING · ROADSHOWS & ACTIVATIONS",
+      "cta": "Discover Excellence"
+    }
+  },
+  "gallery": {
+    "page": {
+      "title": "OUR GALLERY",
+      "subtitle": "Explore our portfolio of creative works and recent achievements",
+      "sectionTitle": "EXPLORE OUR PROJECTS",
+      "sectionSubtitle": "Filter by category to discover our different achievements"
+    },
+    "filters": {
+      "all": "All"
+    },
+    "modal": {
+      "category": "CATEGORY",
+      "client": "CLIENT",
+      "year": "YEAR",
+      "about": "About the project",
+      "gallery": "IMAGE GALLERY"
+    },
+    "cta": "View all projects"
+  },
+  "subsidiaryHeader": {
+    "banner": {
+      "message": "You are viewing the {subsidiary} website.",
+      "return": "Return to Genius AD District",
+      "dismiss": "Close banner"
     }
   },
   "homepage": {

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1,12 +1,28 @@
 {
   "common": {
     "languageName": "Français",
-    "switchLanguage": "Passer à l'anglais",
+    "switchLanguage": "Changer de langue",
+    "languageSwitcher": {
+      "switchToEnglish": "Passer en anglais",
+      "switchToFrench": "Passer en français",
+      "short": {
+        "en": "EN",
+        "fr": "FR"
+      },
+      "languageNames": {
+        "en": "Anglais",
+        "fr": "Français"
+      },
+      "current": "Langue actuelle : {language}"
+    },
     "navigation": {
       "home": "Accueil",
       "about": "À propos",
       "caseStudies": "Études de cas",
       "subsidiaries": "Filiales",
+      "services": "Services",
+      "projects": "Projets",
+      "gallery": "Galerie",
       "contact": "Contact"
     },
     "footer": {
@@ -32,6 +48,10 @@
       "cancel": "Annuler",
       "save": "Enregistrer"
     },
+    "accessibility": {
+      "openMenu": "Ouvrir le menu",
+      "closeMenu": "Fermer le menu"
+    },
     "contact": {
       "title": "Contact",
       "form": {
@@ -41,6 +61,93 @@
         "subject": "Sujet",
         "phone": "Téléphone"
       }
+    }
+  },
+  "navbar": {
+    "menu": {
+      "about": {
+        "label": "À propos",
+        "links": {
+          "history": "Notre histoire",
+          "team": "Notre équipe",
+          "values": "Nos valeurs",
+          "expertise": "Expertises"
+        }
+      },
+      "subsidiaries": {
+        "label": "Filiales",
+        "links": {
+          "mps": "MPS",
+          "labrigad": "LABRIG'Ad",
+          "gamius": "Gamius",
+          "moujeleell": "Mouje & Leell"
+        }
+      },
+      "services": {
+        "label": "Services"
+      },
+      "projects": {
+        "label": "Projets"
+      }
+    }
+  },
+  "footer": {
+    "sections": {
+      "company": {
+        "title": "Entreprise"
+      },
+      "subsidiaries": {
+        "title": "Filiales"
+      },
+      "legal": {
+        "title": "Légal",
+        "links": {
+          "legalNotice": "Mentions légales",
+          "privacy": "Politique de confidentialité",
+          "cookies": "Politique de cookies",
+          "terms": "Conditions générales"
+        }
+      }
+    },
+    "social": {
+      "linkedin": "LinkedIn",
+      "instagram": "Instagram"
+    },
+    "bottom": {
+      "copyright": "© {year} Genius Ad District. Tous droits réservés."
+    }
+  },
+  "home": {
+    "hero": {
+      "title": "AGENCE DE COMMUNICATION ET PRODUCTION",
+      "subtitle": "ÉVÉNEMENTIEL CORPORATE ET GRAND PUBLIC · MARKETING ALTERNATIF · ROADSHOW ET ACTIVATIONS",
+      "cta": "Découvrir l'Excellence"
+    }
+  },
+  "gallery": {
+    "page": {
+      "title": "NOTRE GALERIE",
+      "subtitle": "Découvrez notre portfolio d'œuvres créatives et nos réalisations récentes",
+      "sectionTitle": "EXPLOREZ NOS PROJETS",
+      "sectionSubtitle": "Filtrez par catégorie pour découvrir nos différentes réalisations"
+    },
+    "filters": {
+      "all": "Tous"
+    },
+    "modal": {
+      "category": "CATÉGORIE",
+      "client": "CLIENT",
+      "year": "ANNÉE",
+      "about": "À propos du projet",
+      "gallery": "GALERIE D'IMAGES"
+    },
+    "cta": "Voir tous les projets"
+  },
+  "subsidiaryHeader": {
+    "banner": {
+      "message": "Vous consultez le site {subsidiary}.",
+      "return": "Retourner à Genius AD District",
+      "dismiss": "Fermer la bannière"
     }
   },
     "homepage": {    "hero": {      "title": "GÉNIE CRÉATIF, IMPACT STRATÉGIQUE",      "subtitle": "Nous réinventons l'expérience de marque à travers une fusion unique de créativité audacieuse et d'intelligence stratégique",      "cta": "DÉCOUVRIR NOTRE UNIVERS"    },    "about": {      "title": "L'APPROCHE GENIUS",      "content": "Genius Ad District est un collectif créatif d'élite qui unifie quatre filiales spécialisées sous une vision commune : transformer radicalement la présence de votre marque à travers tous les points de contact avec votre audience. Notre méthodologie exclusive combine innovation visuelle, stratégie data-driven et exécution impeccable pour créer des expériences de marque qui captivent, convertissent et fidélisent."    },    "services": {      "title": "EXPERTISE INTÉGRÉE",      "subtitle": "Solutions holistiques pour marques ambitieuses dans un écosystème médiatique en constante évolution"    },    "subsidiaries": {      "title": "NOTRE ÉCOSYSTÈME CRÉATIF",      "subtitle": "Quatre pôles d'excellence spécialisés, une synergie parfaite pour des résultats exceptionnels"    },    "caseStudies": {      "title": "SUCCÈS TRANSFORMATIONNELS",      "subtitle": "Explorez comment notre approche distinctive redéfinit les standards et génère des résultats mesurables"    },    "testimonials": {      "title": "ILS NOUS FONT CONFIANCE",      "subtitle": "Découvrez l'impact concret de notre collaboration avec des marques visionnaires"    },    "cta": {      "title": "PRÊT À RÉINVENTER VOTRE MARQUE ?",      "subtitle": "Franchissez le pas vers une communication qui transcende les attentes et crée une connexion authentique avec votre audience",      "button": "INITIER VOTRE PROJET"    },    "expertises": {      "title": "DOMAINES D'EXCELLENCE",      "subtitle": "Notre maîtrise s'étend à tous les aspects de l'expérience de marque moderne",      "branding": {        "title": "BRANDING STRATÉGIQUE",        "description": "Création et évolution d'identités de marque distinctives qui résonnent profondément avec votre audience cible."      },      "digital": {        "title": "EXPÉRIENCE DIGITALE",        "description": "Conception d'écosystèmes digitaux immersifs qui génèrent engagement et conversion."      },      "events": {        "title": "ACTIVATION ÉVÉNEMENTIELLE",        "description": "Organisation d'expériences physiques mémorables qui renforcent la connexion émotionnelle avec votre marque."      },      "production": {        "title": "PRODUCTION PREMIUM",        "description": "Fabrication d'actifs visuels et matériels d'exception qui incarnent l'excellence de votre marque."      }    },    "technologies": {      "title": "INNOVATION TECHNOLOGIQUE",      "subtitle": "Notre R&D intègre les technologies les plus avancées pour propulser votre communication",      "ai": "Intelligence Artificielle Créative",      "ar": "Réalité Augmentée & Virtuelle",      "data": "Analyse Prédictive & Data Visualization",      "automation": "Marketing Automation & Personnalisation"    }


### PR DESCRIPTION
## Summary
- use next-intl translations for header, navigation and language switcher controls across the site
- translate the footer, gallery page and reusable gallery component with locale-aware links
- add hero copy translations and supporting i18n keys for shared navigation, footer and subsidiary banner messaging

## Testing
- `npm run lint` *(fails: command prompts for ESLint setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d50e6319648327b005e8176e7ad03d