### PR TITLE
Fix usePathname import for locale handling

### DIFF
--- a/src/components/molecules/LanguageSwitcher.tsx
+++ b/src/components/molecules/LanguageSwitcher.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { useLocale, useTranslations } from 'next-intl';
-import { usePathname } from 'next/navigation';
+import { usePathname } from '@/navigation';
 import { Link } from '@/navigation';
 import { Button } from '@/components/atoms/Button';
 

--- a/src/components/ui/navbar-demo.tsx
+++ b/src/components/ui/navbar-demo.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, type ReactNode } from 'react';
 import { Info, Building2, Briefcase, Code2, Layers, ChevronDown, ChevronUp } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
-import { usePathname } from 'next/navigation';
+import { usePathname } from '@/navigation';
 import Image from "next/image";
 import { cn } from "@/lib/utils";
 import { Link } from '@/navigation';


### PR DESCRIPTION
Update `usePathname` imports to `@/navigation` to ensure correct locale handling with locale-aware `Link` components.

---
<a href="https://cursor.com/background-agent?bcId=bc-9bb08dc5-fedc-4628-a2a2-e68295fa6ddd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9bb08dc5-fedc-4628-a2a2-e68295fa6ddd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

